### PR TITLE
Fixed view templating process

### DIFF
--- a/src/Powerup/Templates/CreateAlterTemplate.cs
+++ b/src/Powerup/Templates/CreateAlterTemplate.cs
@@ -30,7 +30,7 @@ GO
 {2}
 ";
 
-        readonly Regex removeCreate = new Regex(@"^(CREATE)\s.*(PROCEDURE |PROC |VIEW [\s\w\.])(.*)$", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+        readonly Regex removeCreate = new Regex(@"^(CREATE)\s.*(PROCEDURE |PROC |VIEW )(.*)$", RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
         public CreateAlterTemplate(SqlObject sqlObject)
             : base(sqlObject)


### PR DESCRIPTION
Removed expectation that there would be two spaces between the CREATE
VIEW and the name of the view so that it matches the PROC and
PROCEDURE patterns. This was causing the replacement of CREATE with ALTER to fail if there
was only one space between the CREATE VIEW and the name of the view.
