### PR TITLE
Initial support for indexes

### DIFF
--- a/src/Powerup/Application.cs
+++ b/src/Powerup/Application.cs
@@ -18,9 +18,9 @@ namespace Powerup
             this.conn = conn;
             _typesToFind = new List<IQueryBase>
                                                {
-                                                   //new ProcedureQuery(),
-                                                   //new FunctionQuery(),
-                                                   //new ViewQuery(),
+                                                   new ProcedureQuery(),
+                                                   new FunctionQuery(),
+                                                   new ViewQuery(),
                                                    new IndexQuery()
                                                };
 

--- a/src/Powerup/Application.cs
+++ b/src/Powerup/Application.cs
@@ -48,7 +48,7 @@ namespace Powerup
                                 _sqlObject.Add(type.MakeSqlObject(con.Database,
                                                                   reader[1].ToString(),
                                                                   reader[0].ToString(),
-                                                                  (int) reader[2]));
+                                                                  (int)reader[2]));
                             }
                         }
                     }
@@ -59,35 +59,19 @@ namespace Powerup
 
         public void AddCodeToEntities()
         {
-            AddCodeToObject();
+            using (var con = this.conn.ConnectionStringBuilder.CreateConnection())
+            {
+                con.Open();
+                foreach (var obj in this._sqlObject)
+                {
+                    obj.ParentQuery.AddCode(con, obj);
+                }
+            }
         }
 
         public void WriteOutPut()
         {
-            
-        }
 
-        private void AddCodeToObject()
-        {
-            foreach (var sqlObject in _sqlObject)
-            {
-                using (var con = conn.ConnectionStringBuilder.CreateConnection())
-                using (var cmd = new SqlCommand(sqlObject.Query, con))
-                {
-                    cmd.Parameters.Add(new SqlParameter("@1", sqlObject.ObjectId));
-                    con.Open();
-                    using (var reader = cmd.ExecuteReader())
-                    {
-                        if (!reader.HasRows) return;
-                        while (reader.Read())
-                        {
-                            sqlObject.Code += reader[0].ToString();
-                        }
-                        sqlObject.AddCodeTemplate();
-                    }
-                }
-            }           
         }
-
     }
 }

--- a/src/Powerup/Application.cs
+++ b/src/Powerup/Application.cs
@@ -18,9 +18,10 @@ namespace Powerup
             this.conn = conn;
             _typesToFind = new List<IQueryBase>
                                                {
-                                                   new ProcedureQuery(),
-                                                   new FunctionQuery(),
-                                                   new ViewQuery()
+                                                   //new ProcedureQuery(),
+                                                   //new FunctionQuery(),
+                                                   //new ViewQuery(),
+                                                   new IndexQuery()
                                                };
 
         }

--- a/src/Powerup/Powerup.csproj
+++ b/src/Powerup/Powerup.csproj
@@ -53,6 +53,7 @@
     <Compile Include="SqlQueries\IQueryBase.cs" />
     <Compile Include="SqlQueries\QueryBase.cs" />
     <Compile Include="SqlQueries\ProcedureQuery.cs" />
+    <Compile Include="SqlQueries\SysObjectQueryBase.cs" />
     <Compile Include="SqlQueries\ViewQuery.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Powerup/Powerup.csproj
+++ b/src/Powerup/Powerup.csproj
@@ -50,15 +50,20 @@
     <Compile Include="SqlObjects\SqlObject.cs" />
     <Compile Include="SqlObjects\SqlType.cs" />
     <Compile Include="SqlQueries\FunctionQuery.cs" />
+    <Compile Include="SqlQueries\IndexQuery.cs" />
     <Compile Include="SqlQueries\IQueryBase.cs" />
     <Compile Include="SqlQueries\QueryBase.cs" />
     <Compile Include="SqlQueries\ProcedureQuery.cs" />
+    <Compile Include="SqlQueries\SysColumn.cs" />
+    <Compile Include="SqlQueries\SysIndex.cs" />
     <Compile Include="SqlQueries\SysObjectQueryBase.cs" />
+    <Compile Include="SqlQueries\SysTable.cs" />
     <Compile Include="SqlQueries\ViewQuery.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Templates\CreateAlterTemplate.cs" />
     <Compile Include="Templates\DropCreateTemplate.cs" />
+    <Compile Include="Templates\VoidTemplate.cs" />
     <Compile Include="Templates\ITemplate.cs" />
     <Compile Include="Templates\TemplateBase.cs" />
   </ItemGroup>

--- a/src/Powerup/Powerup.csproj
+++ b/src/Powerup/Powerup.csproj
@@ -54,7 +54,7 @@
     <Compile Include="SqlQueries\IQueryBase.cs" />
     <Compile Include="SqlQueries\QueryBase.cs" />
     <Compile Include="SqlQueries\ProcedureQuery.cs" />
-    <Compile Include="SqlQueries\SysColumn.cs" />
+    <Compile Include="SqlQueries\SysIndexColumn.cs" />
     <Compile Include="SqlQueries\SysIndex.cs" />
     <Compile Include="SqlQueries\SysObjectQueryBase.cs" />
     <Compile Include="SqlQueries\SysTable.cs" />

--- a/src/Powerup/SqlObjects/SqlObject.cs
+++ b/src/Powerup/SqlObjects/SqlObject.cs
@@ -20,10 +20,17 @@ namespace Powerup.SqlObjects
         public int ObjectId { get; set; }
         public SqlType SqlType { get; set; }
         public string Code { get; set; }
-        public string Query { get { return parentQuery.TextSql; } }
         public ITemplate ThingToTemplate { get { return codeTemplate; } }
         public string Folder { get { return parentQuery.Folder; } }
         public string Database { get; private set; }
+
+        public IQueryBase ParentQuery
+        {
+            get
+            {
+                return this.parentQuery;
+            }
+        }
 
         public void AddCodeTemplate()
         {

--- a/src/Powerup/SqlQueries/FunctionQuery.cs
+++ b/src/Powerup/SqlQueries/FunctionQuery.cs
@@ -7,7 +7,16 @@ namespace Powerup.SqlQueries
     {
         public override string NameSql
         {
-            get { return string.Format(nameSql, "in ('FN','TF','IF')"); }
+            get
+            {
+                return @"SELECT  o.name Name, s.name [Schema], o.object_id
+                FROM    sys.objects o
+                INNER JOIN sys.schemas s 
+	                ON o.schema_id = s.schema_id
+                where o.type in ('FN','TF','IF')
+	                and o.name not like 'dt_%'
+                order by o.object_id";
+            }
         }
 
         public override string Folder

--- a/src/Powerup/SqlQueries/FunctionQuery.cs
+++ b/src/Powerup/SqlQueries/FunctionQuery.cs
@@ -3,7 +3,7 @@ using Powerup.Templates;
 
 namespace Powerup.SqlQueries
 {
-    public class FunctionQuery : QueryBase
+    public class FunctionQuery : SysObjectQueryBase
     {
         public override string NameSql
         {

--- a/src/Powerup/SqlQueries/IQueryBase.cs
+++ b/src/Powerup/SqlQueries/IQueryBase.cs
@@ -3,10 +3,14 @@ using Powerup.Templates;
 
 namespace Powerup.SqlQueries
 {
+    using System.Data.SqlClient;
+
     public interface IQueryBase
     {
         string NameSql { get; }
-        string TextSql { get; }
+
+        void AddCode(SqlConnection connection, SqlObject obj);
+
         string Database { get; }
         string Folder { get; }
         SqlObject MakeSqlObject(string dataBase, string schema, string name, int objectId);

--- a/src/Powerup/SqlQueries/IndexQuery.cs
+++ b/src/Powerup/SqlQueries/IndexQuery.cs
@@ -69,7 +69,7 @@ ORDER BY TableName
                             };
                         }
 
-                        index.Columns.Add(new SysColumn
+                        index.Columns.Add(new SysIndexColumn
                         {
                             Id = Convert.ToInt32(reader[5]),
                             Name = Convert.ToString(reader[2])

--- a/src/Powerup/SqlQueries/IndexQuery.cs
+++ b/src/Powerup/SqlQueries/IndexQuery.cs
@@ -75,7 +75,8 @@ ORDER BY TableName
                         {
                             Id = Convert.ToInt32(reader[5]),
                             Name = Convert.ToString(reader[2]),
-                            IsDescending = Convert.ToBoolean(reader[8])
+                            IsDescending = Convert.ToBoolean(reader[8]),
+                            IsIncluded = Convert.ToBoolean(reader[9])
                         });
                     }
                     var buffer = new StringBuilder();
@@ -103,7 +104,7 @@ ORDER BY TableName
                     buffer.AppendFormat(" {0} INDEX [{1}]", index.Type, index.Name);
                     buffer.AppendLine();
                     buffer.AppendFormat("ON [{0}].[{1}]", index.Table.Schema, index.Table.Name);
-                    buffer.AppendFormat("({0})", string.Join(", ", index.Columns.Select(
+                    buffer.AppendFormat("({0})", string.Join(", ", index.Columns.Where(c => !c.IsIncluded).Select(
                         c =>
                         {
                             if (c.IsDescending)
@@ -113,6 +114,12 @@ ORDER BY TableName
 
                             return c.Name;
                         })));
+                    buffer.AppendLine();
+                    if (index.Columns.Any(c => c.IsIncluded))
+                    {
+                        buffer.AppendFormat("INCLUDE ({0})", string.Join(", ", index.Columns.Where(c => c.IsIncluded).Select(c => c.Name)));
+                    }
+
                     obj.Code += buffer.ToString();
                     obj.AddCodeTemplate();
                 }

--- a/src/Powerup/SqlQueries/IndexQuery.cs
+++ b/src/Powerup/SqlQueries/IndexQuery.cs
@@ -31,6 +31,7 @@
 ,ic.index_column_id AS ColumnId
 ,ind.is_unique AS IsUnique
 ,ind.type_desc as Type
+,ic.is_descending_key AS IsDescending
 FROM sys.indexes ind 
 JOIN sys.index_columns ic ON  ind.object_id = ic.object_id and ind.index_id = ic.index_id 
 JOIN sys.columns col ON ic.object_id = col.object_id and ic.column_id = col.column_id 
@@ -93,7 +94,16 @@ ORDER BY TableName
                     buffer.AppendFormat(" {0} INDEX [{1}]", index.Type, index.Name);
                     buffer.AppendLine();
                     buffer.AppendFormat("ON [{0}].[{1}]", index.Table.Schema, index.Table.Name);
-                    buffer.AppendFormat("({0})", string.Join(", ", index.Columns.Select(c => c.Name)));
+                    buffer.AppendFormat("({0})", string.Join(", ", index.Columns.Select(
+                        c =>
+                        {
+                            if (c.IsDescending)
+                            {
+                                return c.Name + " DESC";
+                            }
+
+                            return c.Name;
+                        })));
                     obj.Code += buffer.ToString();
                     obj.AddCodeTemplate();
                 }

--- a/src/Powerup/SqlQueries/IndexQuery.cs
+++ b/src/Powerup/SqlQueries/IndexQuery.cs
@@ -1,0 +1,130 @@
+﻿namespace Powerup.SqlQueries
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Data;
+    using System.Data.SqlClient;
+    using System.Linq;
+    using System.Text;
+
+    using Powerup.SqlObjects;
+    using Powerup.Templates;
+
+    public class IndexQuery : QueryBase
+    {
+        public override string Folder
+        {
+            get
+            {
+                return "indexes";
+            }
+        }
+
+        public override void AddCode(SqlConnection connection, SqlObject obj)
+        {
+            SysIndex index = null;
+            using (var cmd = new SqlCommand(@"SELECT ind.index_id AS IndexId
+,ind.name AS IndexName
+,col.name AS ColumnName
+,t.name AS TableName
+,s.name AS SchemaName
+,ic.index_column_id AS ColumnId
+,ind.is_unique AS IsUnique
+,ind.type_desc as Type
+FROM sys.indexes ind 
+JOIN sys.index_columns ic ON  ind.object_id = ic.object_id and ind.index_id = ic.index_id 
+JOIN sys.columns col ON ic.object_id = col.object_id and ic.column_id = col.column_id 
+JOIN sys.tables t ON ind.object_id = t.object_id 
+JOIN sys.schemas s ON t.schema_id = s.schema_id
+WHERE ind.name = @NAME
+  AND ind.index_id = @ID
+ORDER BY TableName
+,IndexId
+,ColumnId", connection))
+            {
+                cmd.Parameters.Add("@NAME", SqlDbType.NVarChar, 128);
+                cmd.Parameters.Add("@ID", SqlDbType.Int);
+                cmd.Parameters["@NAME"].Value = obj.Name;
+                cmd.Parameters["@ID"].Value = obj.ObjectId;
+                using (var reader = cmd.ExecuteReader())
+                {
+                    if (!reader.HasRows) return;
+                    while (reader.Read())
+                    {
+                        if (index == null)
+                        {
+                            var tbl = new SysTable
+                            {
+                                Name = reader[3].ToString(),
+                                Schema = reader[4].ToString()
+                            };
+
+                            index = new SysIndex
+                            {
+                                Id = Convert.ToInt32(reader[0]),
+                                Name = reader[1].ToString(),
+                                Table = tbl,
+                                Type = reader[7].ToString(),
+                                IsUnique = Convert.ToBoolean(reader[6])
+                            };
+                        }
+
+                        index.Columns.Add(new SysColumn
+                        {
+                            Id = Convert.ToInt32(reader[5]),
+                            Name = Convert.ToString(reader[2])
+                        });
+                    }
+                    var buffer = new StringBuilder();
+                    buffer.Append(@"CREATE");
+                    if (index.IsUnique)
+                    {
+                        buffer.Append(" UNIQUE");
+                    }
+
+                    buffer.AppendFormat(" {0} INDEX", index.Type);
+                    buffer.Append(" ");
+                    buffer.AppendLine(index.Name);
+                    buffer.AppendLine("ON");
+                    buffer.AppendFormat("[{0}].[{1}]", index.Table.Schema, index.Table.Name);
+                    buffer.AppendFormat("({0})", string.Join(", ", index.Columns.Select(c => c.Name)));
+                    buffer.AppendLine();
+                    buffer.AppendLine("WITH");
+                    buffer.AppendLine("(DROP_EXISTING = ON);");
+                    obj.Code += buffer.ToString();
+                    obj.AddCodeTemplate();
+                }
+            }
+        }
+
+        public override string NameSql
+        {
+            get
+            {
+                return @"SELECT DISTINCT ind.name AS IndexName
+,s.name AS SchemaName
+,ind.index_id AS IndexId
+FROM sys.indexes ind
+JOIN sys.tables t ON ind.object_id = t.object_id 
+JOIN sys.schemas s ON t.schema_id = s.schema_id
+WHERE ind.index_id <> 0
+  AND ind.is_primary_key = 0 
+  AND ind.is_unique_constraint = 0 
+  AND t.is_ms_shipped = 0";
+            }
+        }
+
+        public override SqlType SqlType
+        {
+            get
+            {
+                return SqlType.Index;
+            }
+        }
+
+        public override ITemplate TemplateToUse(SqlObject sqlObject)
+        {
+            return new VoidTemplate(sqlObject);
+        }
+    }
+}

--- a/src/Powerup/SqlQueries/IndexQuery.cs
+++ b/src/Powerup/SqlQueries/IndexQuery.cs
@@ -77,14 +77,21 @@ ORDER BY TableName
                         });
                     }
                     var buffer = new StringBuilder();
+                    buffer.AppendLine(@"DECLARE @Name nvarchar(128), @TableName nvarchar(128), @TableSchema nvarchar(128)");
                     buffer.AppendFormat(
-                        @"IF  EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID(N'[{0}].[{1}]') AND UPPER(name) = UPPER(N'{2}'))
-    DROP INDEX [{2}] ON [{0}].[{1}]",
-                        index.Table.Schema,
+                        @"SELECT @Name = N'{0}', @TableName=N'{1}', @TableSchema = N'{2}'",
+                        index.Name,
                         index.Table.Name,
-                        index.Name);
+                        index.Table.Schema);
                     buffer.AppendLine();
+                    buffer.AppendLine(
+                        "IF  EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID('[' + @TableSchema + '].[' + @TableName + ']') AND UPPER(name) = UPPER(@Name))");
+                    buffer.AppendLine(
+                        "    EXECUTE('DROP INDEX [' + @Name + '] ON [' + @TableSchema + '].[' + @TableName + ']')");
+                    buffer.AppendLine();
+                    buffer.AppendLine(@"PRINT 'Creating index [' + @Name + '] on table [' + @TableSchema + '].[' + @TableName + ']'");
                     buffer.AppendLine("GO");
+                    buffer.AppendLine();
                     buffer.Append(@"CREATE");
                     if (index.IsUnique)
                     {

--- a/src/Powerup/SqlQueries/IndexQuery.cs
+++ b/src/Powerup/SqlQueries/IndexQuery.cs
@@ -32,6 +32,7 @@
 ,ind.is_unique AS IsUnique
 ,ind.type_desc as Type
 ,ic.is_descending_key AS IsDescending
+,ic.is_included_column AS IsIncluded
 FROM sys.indexes ind 
 JOIN sys.index_columns ic ON  ind.object_id = ic.object_id and ind.index_id = ic.index_id 
 JOIN sys.columns col ON ic.object_id = col.object_id and ic.column_id = col.column_id 
@@ -73,7 +74,8 @@ ORDER BY TableName
                         index.Columns.Add(new SysIndexColumn
                         {
                             Id = Convert.ToInt32(reader[5]),
-                            Name = Convert.ToString(reader[2])
+                            Name = Convert.ToString(reader[2]),
+                            IsDescending = Convert.ToBoolean(reader[8])
                         });
                     }
                     var buffer = new StringBuilder();

--- a/src/Powerup/SqlQueries/IndexQuery.cs
+++ b/src/Powerup/SqlQueries/IndexQuery.cs
@@ -70,8 +70,8 @@ ORDER BY TableName
                                 Table = tbl,
                                 Type = reader[7].ToString(),
                                 IsUnique = Convert.ToBoolean(reader[6]),
-                                HasFilter = Convert.ToBoolean(reader[7]),
-                                FilterDefinition = Convert.ToString(reader[8])
+                                HasFilter = Convert.ToBoolean(reader[8]),
+                                FilterDefinition = Convert.ToString(reader[9])
                             };
                         }
 

--- a/src/Powerup/SqlQueries/ProcedureQuery.cs
+++ b/src/Powerup/SqlQueries/ProcedureQuery.cs
@@ -4,7 +4,20 @@ namespace Powerup.SqlQueries
 {
     public class ProcedureQuery : SysObjectQueryBase
     {
-        public override string NameSql { get { return string.Format(nameSql, "= 'P'"); } }
+        public override string NameSql
+        {
+            get
+            {
+                return @"SELECT  o.name Name, s.name [Schema], o.object_id
+                FROM    sys.objects o
+                INNER JOIN sys.schemas s 
+	                ON o.schema_id = s.schema_id
+                where o.type = 'P'
+	                and o.name not like 'dt_%'
+                order by o.object_id";
+            }
+        }
+
         public override string Folder { get {return "sprocs";}}
         public override SqlType SqlType { get { return SqlType.Procedure; } }
     }

--- a/src/Powerup/SqlQueries/ProcedureQuery.cs
+++ b/src/Powerup/SqlQueries/ProcedureQuery.cs
@@ -2,7 +2,7 @@ using Powerup.SqlObjects;
 
 namespace Powerup.SqlQueries
 {
-    public class ProcedureQuery : QueryBase
+    public class ProcedureQuery : SysObjectQueryBase
     {
         public override string NameSql { get { return string.Format(nameSql, "= 'P'"); } }
         public override string Folder { get {return "sprocs";}}

--- a/src/Powerup/SqlQueries/QueryBase.cs
+++ b/src/Powerup/SqlQueries/QueryBase.cs
@@ -6,36 +6,21 @@ namespace Powerup.SqlQueries
 {
     public abstract class QueryBase : IQueryBase
     {
-        protected string nameSql =
-            @"SELECT  o.name Name, s.name [Schema], o.object_id
-                FROM    sys.objects o
-                INNER JOIN sys.schemas s 
-	                ON o.schema_id = s.schema_id
-                where o.type {0}
-	                and o.name not like 'dt_%'
-                order by o.object_id";
-
-        string textQuery = @"SELECT c.text
-                FROM SYS.syscomments c
-                where c.id = @1
-                order by c.colid";
-
         protected QueryBase()
         {
             SqlObjects = new List<SqlObject>();
         }
 
         public abstract string NameSql { get; }
-        public string TextSql { get { return textQuery; } }
+
+        public abstract string TextSql { get; }
+
         public abstract string Folder { get; }
         public string Database { get; private set; }
         public IList<SqlObject> SqlObjects { get; private set; }
         public abstract SqlType SqlType { get; }
-        
-        public virtual ITemplate TemplateToUse(SqlObject sqlObject)
-        {
-            return new CreateAlterTemplate(sqlObject);
-        }
+
+        public abstract ITemplate TemplateToUse(SqlObject sqlObject);
 
         public void AddSqlObject(SqlObject sqlObject)
         {

--- a/src/Powerup/SqlQueries/QueryBase.cs
+++ b/src/Powerup/SqlQueries/QueryBase.cs
@@ -4,6 +4,8 @@ using Powerup.Templates;
 
 namespace Powerup.SqlQueries
 {
+    using System.Data.SqlClient;
+
     public abstract class QueryBase : IQueryBase
     {
         protected QueryBase()
@@ -13,9 +15,10 @@ namespace Powerup.SqlQueries
 
         public abstract string NameSql { get; }
 
-        public abstract string TextSql { get; }
-
         public abstract string Folder { get; }
+
+        public abstract void AddCode(SqlConnection connection, SqlObject obj);
+
         public string Database { get; private set; }
         public IList<SqlObject> SqlObjects { get; private set; }
         public abstract SqlType SqlType { get; }

--- a/src/Powerup/SqlQueries/SysColumn.cs
+++ b/src/Powerup/SqlQueries/SysColumn.cs
@@ -1,0 +1,14 @@
+﻿namespace Powerup.SqlQueries
+{
+    public class SysColumn
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public override sealed string ToString()
+        {
+            return this.Name ?? base.ToString();
+        }
+    }
+}

--- a/src/Powerup/SqlQueries/SysIndex.cs
+++ b/src/Powerup/SqlQueries/SysIndex.cs
@@ -6,10 +6,10 @@
     {
         public SysIndex()
         {
-            this.Columns = new List<SysColumn>();
+            this.Columns = new List<SysIndexColumn>();
         }
 
-        public IList<SysColumn> Columns { get; }
+        public IList<SysIndexColumn> Columns { get; }
 
         public SysTable Table { get; set; }
 

--- a/src/Powerup/SqlQueries/SysIndex.cs
+++ b/src/Powerup/SqlQueries/SysIndex.cs
@@ -21,6 +21,11 @@
 
         public bool IsUnique { get; set; }
 
+        public bool HasFilter { get; set; }
+
+        public string FilterDefinition { get; set; }
+
+
         public override sealed string ToString()
         {
             return this.Name ?? base.ToString();

--- a/src/Powerup/SqlQueries/SysIndex.cs
+++ b/src/Powerup/SqlQueries/SysIndex.cs
@@ -1,0 +1,29 @@
+﻿namespace Powerup.SqlQueries
+{
+    using System.Collections.Generic;
+
+    public class SysIndex
+    {
+        public SysIndex()
+        {
+            this.Columns = new List<SysColumn>();
+        }
+
+        public IList<SysColumn> Columns { get; }
+
+        public SysTable Table { get; set; }
+
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string Type { get; set; }
+
+        public bool IsUnique { get; set; }
+
+        public override sealed string ToString()
+        {
+            return this.Name ?? base.ToString();
+        }
+    }
+}

--- a/src/Powerup/SqlQueries/SysIndexColumn.cs
+++ b/src/Powerup/SqlQueries/SysIndexColumn.cs
@@ -8,6 +8,8 @@
 
         public bool IsDescending { get; set; }
 
+        public bool IsIncluded { get; set; }
+
         public override sealed string ToString()
         {
             return this.Name ?? base.ToString();

--- a/src/Powerup/SqlQueries/SysIndexColumn.cs
+++ b/src/Powerup/SqlQueries/SysIndexColumn.cs
@@ -6,6 +6,8 @@
 
         public string Name { get; set; }
 
+        public bool IsDescending { get; set; }
+
         public override sealed string ToString()
         {
             return this.Name ?? base.ToString();

--- a/src/Powerup/SqlQueries/SysIndexColumn.cs
+++ b/src/Powerup/SqlQueries/SysIndexColumn.cs
@@ -1,6 +1,6 @@
 ﻿namespace Powerup.SqlQueries
 {
-    public class SysColumn
+    public class SysIndexColumn
     {
         public int Id { get; set; }
 

--- a/src/Powerup/SqlQueries/SysObjectQueryBase.cs
+++ b/src/Powerup/SqlQueries/SysObjectQueryBase.cs
@@ -1,16 +1,32 @@
 ﻿namespace Powerup.SqlQueries
 {
+    using System.Data.SqlClient;
+
     using Powerup.SqlObjects;
     using Powerup.Templates;
 
     public abstract class SysObjectQueryBase : QueryBase
     {
-        string textQuery = @"SELECT c.text
+        public override void AddCode(SqlConnection connection, SqlObject obj)
+        {
+            using (var cmd = new SqlCommand(@"SELECT c.text
                 FROM SYS.syscomments c
                 where c.id = @1
-                order by c.colid";
+                order by c.colid", connection))
+            {
+                cmd.Parameters.Add(new SqlParameter("@1", obj.ObjectId));
+                using (var reader = cmd.ExecuteReader())
+                {
+                    if (!reader.HasRows) return;
+                    while (reader.Read())
+                    {
+                        obj.Code += reader[0].ToString();
+                    }
 
-        public override string TextSql { get { return textQuery; } }
+                    obj.AddCodeTemplate();
+                }
+            }
+        }
 
         public override ITemplate TemplateToUse(SqlObject sqlObject)
         {

--- a/src/Powerup/SqlQueries/SysObjectQueryBase.cs
+++ b/src/Powerup/SqlQueries/SysObjectQueryBase.cs
@@ -5,14 +5,6 @@
 
     public abstract class SysObjectQueryBase : QueryBase
     {
-        protected string nameSql = @"SELECT  o.name Name, s.name [Schema], o.object_id
-                FROM    sys.objects o
-                INNER JOIN sys.schemas s 
-	                ON o.schema_id = s.schema_id
-                where o.type {0}
-	                and o.name not like 'dt_%'
-                order by o.object_id";
-
         string textQuery = @"SELECT c.text
                 FROM SYS.syscomments c
                 where c.id = @1

--- a/src/Powerup/SqlQueries/SysObjectQueryBase.cs
+++ b/src/Powerup/SqlQueries/SysObjectQueryBase.cs
@@ -1,0 +1,28 @@
+﻿namespace Powerup.SqlQueries
+{
+    using Powerup.SqlObjects;
+    using Powerup.Templates;
+
+    public abstract class SysObjectQueryBase : QueryBase
+    {
+        protected string nameSql = @"SELECT  o.name Name, s.name [Schema], o.object_id
+                FROM    sys.objects o
+                INNER JOIN sys.schemas s 
+	                ON o.schema_id = s.schema_id
+                where o.type {0}
+	                and o.name not like 'dt_%'
+                order by o.object_id";
+
+        string textQuery = @"SELECT c.text
+                FROM SYS.syscomments c
+                where c.id = @1
+                order by c.colid";
+
+        public override string TextSql { get { return textQuery; } }
+
+        public override ITemplate TemplateToUse(SqlObject sqlObject)
+        {
+            return new CreateAlterTemplate(sqlObject);
+        }
+    }
+}

--- a/src/Powerup/SqlQueries/SysTable.cs
+++ b/src/Powerup/SqlQueries/SysTable.cs
@@ -1,0 +1,14 @@
+﻿namespace Powerup.SqlQueries
+{
+    public class SysTable
+    {
+        public string Name { get; set; }
+
+        public string Schema { get; set; }
+
+        public override sealed string ToString()
+        {
+            return this.Name ?? base.ToString();
+        }
+    }
+}

--- a/src/Powerup/SqlQueries/ViewQuery.cs
+++ b/src/Powerup/SqlQueries/ViewQuery.cs
@@ -2,7 +2,7 @@ using Powerup.SqlObjects;
 
 namespace Powerup.SqlQueries
 {
-    public class ViewQuery : QueryBase
+    public class ViewQuery : SysObjectQueryBase
     {
         public override string NameSql
         {

--- a/src/Powerup/SqlQueries/ViewQuery.cs
+++ b/src/Powerup/SqlQueries/ViewQuery.cs
@@ -6,7 +6,16 @@ namespace Powerup.SqlQueries
     {
         public override string NameSql
         {
-            get { return string.Format(nameSql, "= 'V'"); }
+            get
+            {
+                return @"SELECT  o.name Name, s.name [Schema], o.object_id
+                FROM    sys.objects o
+                INNER JOIN sys.schemas s 
+	                ON o.schema_id = s.schema_id
+                where o.type = 'V'
+	                and o.name not like 'dt_%'
+                order by o.object_id";
+            }
         }
 
         public override string Folder

--- a/src/Powerup/Templates/VoidTemplate.cs
+++ b/src/Powerup/Templates/VoidTemplate.cs
@@ -1,0 +1,27 @@
+﻿namespace Powerup.Templates
+{
+    using System;
+    using System.Text;
+
+    using Powerup.SqlObjects;
+
+    public class VoidTemplate : TemplateBase
+    {
+        StringBuilder buffer = new StringBuilder();
+
+        public VoidTemplate(SqlObject sqlObject)
+            : base(sqlObject)
+        {
+        }
+
+        public override void AddText(string text)
+        {
+            this.buffer.Append(text);
+        }
+
+        public override string TemplatedProcedure()
+        {
+            return this.buffer.ToString();
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a provider named `IndexQuery` that creates drop-create scripts for indexes.

I changed a lot of existing code to make this possible. That was necessary because indexes are not in the `sys.objects` table, but instead require custom code that wraps the `sys.indexes` table.

The `IndexQuery` provider does not currently use the `ITemplate` system beyond what is necessary to make the application work. I added a `VoidTemplate` class just for that purpose.

Example of what is generated:

````sql
DECLARE @Name nvarchar(128), @TableName nvarchar(128), @TableSchema nvarchar(128)
SELECT @Name = N'IX_Company_CompanyName', @TableName=N'Company', @TableSchema = N'dbo'
IF  EXISTS (SELECT * FROM sys.indexes WHERE object_id = OBJECT_ID('[' + @TableSchema + '].[' + @TableName + ']') AND UPPER(name) = UPPER(@Name))
    EXECUTE('DROP INDEX [' + @Name + '] ON [' + @TableSchema + '].[' + @TableName + ']')

PRINT 'Creating index [' + @Name + '] on table [' + @TableSchema + '].[' + @TableName + ']'
GO

CREATE NONCLUSTERED INDEX [IX_Company_CompanyName]
ON [dbo].[Company](CompanyName)
````

The initial implementation only generates scripts for user-defined indexes. Implicit indexes (primary keys, unique constraints) are ignored.

Final notes:
* Supports `sys.indexes.type`
  * Tested with `CLUSTERED`
  * Tested with `NONCLUSTERED`
  * **Not** tested with `XML`
  * **Not** tested with `SPATIAL`
* Supports `sys.indexes.is_unique`
* Supports `sys.indexes.has_filter` and `sys.indexes.filter_definition`
* Supports `sys.index_columns.is_descending_key`
* Supports `sys.index_columns.is_included_column`

Looking at the documentation, there's a whole bunch of options that I didn't implement.
https://msdn.microsoft.com/en-us/library/ms188783(v=sql.110).aspx

I've never even used half of these options. I don't really know what they're for, let alone how to implement them.

Resolves #14 