### PR TITLE
Improve templates

### DIFF
--- a/src/Powerup/Templates/CreateAlterTemplate.cs
+++ b/src/Powerup/Templates/CreateAlterTemplate.cs
@@ -19,7 +19,7 @@ namespace Powerup.Templates
 SELECT @Name = N'{0}', @Type = N'{1}', @Schema = N'{2}'
 
 IF NOT EXISTS (SELECT * FROM dbo.sysobjects WHERE id = OBJECT_ID('[' + @Schema + '].[' + @Name + ']'))
-    EXECUTE('CREATE ' + @Type + ' [' + @Schema + '].[' + @Name + '] AS SELECT * FROM sys.objects'
+    EXECUTE('CREATE ' + @Type + ' [' + @Schema + '].[' + @Name + '] AS SELECT * FROM sys.objects')
 
 PRINT 'Creating/Updating ' + @Type + ' [' + @Schema + '].[' + @Name + ']'
 GO

--- a/src/Powerup/Templates/CreateAlterTemplate.cs
+++ b/src/Powerup/Templates/CreateAlterTemplate.cs
@@ -5,31 +5,6 @@ namespace Powerup.Templates
 {
     public class CreateAlterTemplate : TemplateBase
     {
-        /// <summary>
-        /// 0: Name
-        /// 1: Schema
-        /// 2: Code
-        /// 3: Type (PROCEDURE, VIEW, etc)
-        /// 4: Database
-        /// </summary>
-
-        const string template =
-            @"
-DECLARE @Name VarChar(100),@Type VarChar(20), @Schema VarChar(20)
-            SELECT @Name = '{0}', @Type = '{3}', @Schema = '{1}'
-
-IF NOT EXISTS (SELECT * FROM dbo.sysobjects WHERE id = OBJECT_ID(@Schema + '.' +  @Name))
-BEGIN
-  DECLARE @SQL varchar(1000)
-  SET @SQL = 'CREATE ' + @Type + ' ' + @Schema + '.' + @Name + ' AS SELECT * FROM sys.objects'
-  EXECUTE(@SQL)
-END 
-PRINT 'Updating ' + @Type + ' ' + @Schema + '.' + @Name
-GO
-
-{2}
-";
-
         readonly Regex removeCreate = new Regex(@"^(?:\s*)?(CREATE)\s.*(PROCEDURE |PROC |VIEW )(.*)$", RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
         public CreateAlterTemplate(SqlObject sqlObject)
@@ -39,19 +14,27 @@ GO
 
         public override string TemplatedProcedure()
         {
-            return string.Format(template,
-                                    _sqlObject.Name,
-                                    _sqlObject.Schema,
-                                    Proc,
-                                    _sqlObject.SqlType.ToString().ToUpper());
+            return string.Format(
+                @"DECLARE @Name nvarchar(128), @Type nvarchar(20), @Schema nvarchar(128)
+SELECT @Name = N'{0}', @Type = N'{1}', @Schema = N'{2}'
+
+IF NOT EXISTS (SELECT * FROM dbo.sysobjects WHERE id = OBJECT_ID('[' + @Schema + '].[' + @Name + ']'))
+    EXECUTE('CREATE ' + @Type + ' [' + @Schema + '].[' + @Name + '] AS SELECT * FROM sys.objects'
+
+PRINT 'Creating/Updating ' + @Type + ' [' + @Schema + '].[' + @Name + ']'
+GO
+
+{3}",
+                this._sqlObject.Name,
+                this._sqlObject.SqlType.ToString().ToUpper(),
+                this._sqlObject.Schema,
+                this.Proc);
         }
-
-
 
         public override void AddText(string text)
         {
             this.Proc = removeCreate.Replace(text, "ALTER $2 $3");
         }
-        
+
     }
 }

--- a/src/Powerup/Templates/DropCreateTemplate.cs
+++ b/src/Powerup/Templates/DropCreateTemplate.cs
@@ -4,30 +4,27 @@ namespace Powerup.Templates
 {
     public class DropCreateTemplate : TemplateBase
     {
-        /// <summary>
-        /// 0: Name
-        /// 1: Schema
-        /// 2: Code
-        /// 3: Type (PROCEDURE, VIEW, etc)
-        /// 4: Database
-        /// </summary>
-        const string Template =
-            @"IF EXISTS (SELECT * FROM dbo.sysobjects WHERE id = OBJECT_ID(N'{1}.{0}')) DROP {3} {1}.{0}
-GO
-
-{2} ";
-
         public DropCreateTemplate(SqlObject sqlObject) : base(sqlObject)
         {
         }
 
         public override string TemplatedProcedure()
         {
-            return string.Format(Template,
-                                    _sqlObject.Name,
-                                    _sqlObject.Schema,
-                                    Proc,
-                                    _sqlObject.SqlType.ToString().ToUpper());
+            return string.Format(
+                @"DECLARE @Name nvarchar(128), @Type nvarchar(20), @Schema nvarchar(128)
+SELECT @Name = N'{0}', @Type = N'{1}', @Schema = N'{2}'
+
+IF EXISTS (SELECT * FROM dbo.sysobjects WHERE id = OBJECT_ID('[' + @Schema + '].[' + @Name + ']'))  
+    EXECUTE('DROP ' + @Type + ' [' + @Schema + '].[' + @Name + ']')
+
+PRINT 'Creating ' + @Type + ' [' + @Schema + '].[' + @Name + ']'
+GO
+
+{3}",
+                this._sqlObject.Name,
+                this._sqlObject.SqlType.ToString().ToUpper(),
+                this._sqlObject.Schema,
+                this.Proc);
         }
 
         public override void AddText(string text)


### PR DESCRIPTION
This pull request improves the `CreateAlterTemplate` and `DropCreateTemplate`

* Identifier names are now escaped using square brackets
* Input strings are now treated as Unicode with prefix `N`
* The data type of sysobject names is now `nvarchar(128)` (equivalent of `sysname`) instead of `varchar(100)`
* The data type of schema names is now `nvarchar(128)` (equivalent of `sysname`) instead of `varchar(20)`

Resolves #22 